### PR TITLE
Add ChartMoE-Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ chartmoe/train/output/
 chartmoe/train/logs/
 chartmoe/train/ckpt/*
 chartmoe/train/data/*.json
+chartmoe/train/data/ChartMoE-Align
+chartmoe/train/data/SFT

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 [![arXiv](https://img.shields.io/badge/ArXiv-Prepint-red)](https://arxiv.org/abs/2409.03277)
 [![Project Page](https://img.shields.io/badge/Project-Page-brightgreen)](https://chartmoe.github.io/)
-[![Hugging Face Dataset](https://img.shields.io/badge/Hugging%20Face-Model-blue)](https://huggingface.co/IDEA-FinAI/chartmoe)
+[![Hugging Face Model](https://img.shields.io/badge/Hugging%20Face-Model-blue)](https://huggingface.co/IDEA-FinAI/chartmoe)
+[![Hugging Face Dataset](https://img.shields.io/badge/Hugging%20Face-Dataset-8A2BE2)](https://huggingface.co/datasets/Coobiw/ChartMoE-Data)
 
 *If you have any question, feel free to contact [📧](mailto:brian.bw.qu@gmail.com).*
 
@@ -28,13 +29,29 @@
 **ChartMoE** is a multimodal large language model with Mixture-of-Expert connector for advanced chart 1)understanding, 2)replot, 3)editing, 4)highlighting and 5)transformation. 
 
 ## News
-
-- 2025.2.11: 🎉🎉🎉 ChartMoE is selected as ICLR2025 Oral!
-- 2025.1.23: 🎉🎉🎉 ChartMoE is accepted by ICLR2025!
+- 2025.2.16: ChartMoE-Data has been released at [🤗](https://huggingface.co/datasets/Coobiw/ChartMoE-Data). Please download it according to [our instruction](##Download and Organize the ChartMoE-Data)
+- 2025.2.15: Training codes and recipes are released! Please refer to [📖](chartmoe/train/)!
+- 2025.2.11: 🎉🎉🎉 ChartMoE is selected as **ICLR2025 Oral**!
+- 2025.1.23: 🎉🎉🎉 ChartMoE is accepted by **ICLR2025**!
 - 2024.9.10: We release ChartMoE!
 
 ## Training of ChartMoE
-Please refer to [training readme](chartmoe/train/)!
+Please refer to [📖training readme](chartmoe/train/)!
+
+## Download and Organize the ChartMoE-Data
+[🤗ChartMoE Data](https://huggingface.co/Coobiw/ChartMoE-Data) has been released! You can download it by running:
+
+```bash
+cd chartmoe/train
+python scripts/chartmoe_data_download.py
+```
+Datasets will appear at `chartmoe/train/data`.
+
+Then, please unzip these two files.
+```bash
+unzip ChartMoE-Align.zip
+unzip SFT.zip
+```
 
 ## Installation
 **Step 1.** Create a conda environment and activate it.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ unzip ChartMoE-Align.zip
 unzip SFT.zip
 ```
 
+Additionally, I want to announce that the `ChartY_replot` in `ChartMoE-Align` contains data with higher quality and bilingual texts! It may be a good choice to sample more from `ChartY_replot`.
+
 ## Installation
 **Step 1.** Create a conda environment and activate it.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 **ChartMoE** is a multimodal large language model with Mixture-of-Expert connector for advanced chart 1)understanding, 2)replot, 3)editing, 4)highlighting and 5)transformation. 
 
 ## News
-- 2025.2.16: ChartMoE-Data has been released at [🤗](https://huggingface.co/datasets/Coobiw/ChartMoE-Data). Please download it according to [our instruction](#download-and-organize-the-chartmoe-data)
+- 2025.2.16: ChartMoE-Data has been released at [🤗](https://huggingface.co/datasets/Coobiw/ChartMoE-Data). Please download it according to [our instruction](#download-and-organize-the-chartmoe-data).
 - 2025.2.15: Training codes and recipes are released! Please refer to [📖](chartmoe/train/)!
 - 2025.2.11: 🎉🎉🎉 ChartMoE is selected as **ICLR2025 Oral**!
 - 2025.1.23: 🎉🎉🎉 ChartMoE is accepted by **ICLR2025**!

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 **ChartMoE** is a multimodal large language model with Mixture-of-Expert connector for advanced chart 1)understanding, 2)replot, 3)editing, 4)highlighting and 5)transformation. 
 
 ## News
-- 2025.2.16: ChartMoE-Data has been released at [🤗](https://huggingface.co/datasets/Coobiw/ChartMoE-Data). Please download it according to [our instruction](##Download and Organize the ChartMoE-Data)
+- 2025.2.16: ChartMoE-Data has been released at [🤗](https://huggingface.co/datasets/Coobiw/ChartMoE-Data). Please download it according to [our instruction](#download-and-organize-the-chartmoe-data)
 - 2025.2.15: Training codes and recipes are released! Please refer to [📖](chartmoe/train/)!
 - 2025.2.11: 🎉🎉🎉 ChartMoE is selected as **ICLR2025 Oral**!
 - 2025.1.23: 🎉🎉🎉 ChartMoE is accepted by **ICLR2025**!

--- a/chartmoe/generation_utils.py
+++ b/chartmoe/generation_utils.py
@@ -29,6 +29,7 @@ class ChartMoE_Robot:
                 model_path, 
                 trust_remote_code=True
             )
+        print(f"\033[34mLoad model from {model_path}\033[0m")
         self.model = AutoModel.from_pretrained(
                     model_path,
                     trust_remote_code=True,

--- a/chartmoe/train/README.md
+++ b/chartmoe/train/README.md
@@ -9,7 +9,54 @@
 In this part, I'll introduct the training recipes for reproducing ChartMoE. Except for the training recipes, I also provided a checkpoint that can be reproduced according to following instructions. You can find it at [🤗](https://huggingface.co/Coobiw/ChartMoE_Reproduced). **This version has better performance on ChartQA(both with & without PoT).**
 
 
+## Download and Organize the ChartMoE-Data
+[🤗ChartMoE Data](https://huggingface.co/datasets/Coobiw/ChartMoE-Data) has been released! You can download it by running:
 
+```bash
+cd chartmoe/train
+python scripts/chartmoe_data_download.py
+```
+Datasets will appear at `chartmoe/train/data`.
+
+Then, please unzip these two files.
+```bash
+unzip ChartMoE-Align.zip
+unzip SFT.zip
+```
+
+### Data Format
+```python
+  [
+    {
+      "id": "0",
+      "image": ['path/to/image_0.jpg']
+      "conversations": [
+        {
+          "from": "user",
+          "value": "<ImageHere> Please describe these two images in detail."
+        },
+        {
+          "from": "assistant",
+          "value": "......"
+        }
+      ]
+    },
+    {
+      "id": "1",
+      "image": ['path/to/image_1.jpg']
+      "conversations": [
+        {
+          "from": "user",
+          "value": "<ImageHere> what is the color of the dog"
+        },
+        {
+          "from": "assistant",
+          "value": "it is ...."
+        }
+      ]
+    }
+  ]
+```
 
 ## Download InternLM_XComposer2_Enhanced
 

--- a/chartmoe/train/README.md
+++ b/chartmoe/train/README.md
@@ -24,6 +24,8 @@ unzip ChartMoE-Align.zip
 unzip SFT.zip
 ```
 
+Additionally, I want to announce that the `ChartY_replot` in `ChartMoE-Align` contains data with higher quality and bilingual texts! It may be a good choice to sample more from `ChartY_replot`.
+
 ### Data Format
 ```python
   [

--- a/chartmoe/train/scripts/chartmoe_data_download.py
+++ b/chartmoe/train/scripts/chartmoe_data_download.py
@@ -1,0 +1,17 @@
+import huggingface_hub
+import time
+
+def download():
+    try:
+        huggingface_hub.snapshot_download("Coobiw/ChartMoE-Data", local_dir="./data/", repo_type="dataset", resume_download=True)
+        return True
+    except:
+        print("Caught an exception! Retrying...")
+        return False
+
+while True:
+    result = download()
+    if result:
+        print("success")
+        break  # Exit the loop if the function ran successfully
+    time.sleep(1)  # Wait for 1 second before retrying


### PR DESCRIPTION
[🤗ChartMoE Data](https://huggingface.co/datasets/Coobiw/ChartMoE-Data) has been released! You can download it by running:

```bash
cd chartmoe/train
python scripts/chartmoe_data_download.py
```
Datasets will appear at `chartmoe/train/data`.

Then, please unzip these two files.
```bash
unzip ChartMoE-Align.zip
unzip SFT.zip
```

Additionally, I want to announce that the `ChartY_replot` in `ChartMoE-Align` contains data with higher quality and bilingual texts! It may be a good choice to sample more from `ChartY_replot`.